### PR TITLE
Allow config and userprop resources to be passed via the main class

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,32 @@ To convert current user properties into Puppet code use
 
     $ puppet resource openvpnas_userprop
 
+## Defining settings in Hiera for automatic lookup of class parameters
+
+It is also possible to define all settings in Hiera and just `include openvpnas`
+module in your manifest, which will then automatically lookup the class
+parameters from Hiera data. Here is an example of Hiera data:
+
+    openvpnas::package_ensure: installed
+    openvpnas::service_ensure: running
+    openvpnas::service_enable: true
+    openvpnas::service_name: openvpnas
+    openvpnas::config:
+      vpn.tls_refresh.interval:
+        ensure: present
+        value: '100'
+    openvpnas::userprop:
+      openvpn-prop_superuser:
+        ensure: present
+        value: 'true'
+
+To convert current Access Server configuration and user properties into Hiera values use the following commands and adjust the top level keys
+
+    $ puppet resource openvpnas_config --to_yaml
+    $ puppet resource openvpnas_userprop --to_yaml
+
+Note: It was observed that the value of the openvpnas_config resource `subscription.saved_state` changes often and might not be a good idea to set that to a fixed value with Puppet. It is recommended to use eYAML to encrypt the several secrets that are dumped in plain text.
+
 # Warnings
 
 Please note that "sacli" does not do any validation on the data it gets: make

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,0 +1,9 @@
+define openvpnas::config (
+  String $ensure = present,
+  String $value,
+) {
+  openvpnas_config { $name:
+    ensure => $ensure,
+    value => $value,
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,10 +10,15 @@ class openvpnas (
   Enum['running', 'stopped'] $service_ensure = 'running',
   Boolean $service_enable                    = true,
   String $service_name                       = 'openvpnas',
+  Hash $config = {},
+  Hash $userprop = {},
 ) {
   contain 'openvpnas::install'
   contain 'openvpnas::service'
 
   Class['openvpnas::install']
   -> Class['openvpnas::service']
+
+  create_resources(openvpnas::config, $config)
+  create_resources(openvpnas::userprop, $userprop)
 }

--- a/manifests/userprop.pp
+++ b/manifests/userprop.pp
@@ -1,0 +1,9 @@
+define openvpnas::userprop (
+  String $ensure = present,
+  String $value,
+) {
+  openvpnas_userprop { $name:
+    ensure => $ensure,
+    value => $value,
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "openvpn-openvpnas",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "author": "OpenVPN project",
   "summary": "Manage OpenVPN Access Server",
   "license": "BSD-2-Clause",


### PR DESCRIPTION
This is useful when used in conjunction with Hiera automatic binding parameters, in which case the config and userprop can be defined in YAML files and the module just has to be included to expose all functionality.

The data structures expected in Hiera are exactly the same as exported with commands:
```
puppet resource openvpnas_config --to_yaml
puppet resource openvpnas_userprop --to_yaml
```