### PR TITLE
Allow emails as usernames

### DIFF
--- a/lib/puppet/provider/openvpnas_userprop/sacli.rb
+++ b/lib/puppet/provider/openvpnas_userprop/sacli.rb
@@ -8,11 +8,11 @@ Puppet::Type.type(:openvpnas_userprop).provide(:sacli) do
   commands sacli: '/usr/local/openvpn_as/scripts/sacli'
 
   def user
-    resource[:name].split('-').shift
+    resource[:name].split('-')[0..-2].join("-")
   end
 
   def key
-    resource[:name].split('-').drop(1)
+    resource[:name].split('-')[-1]
   end
 
   def create

--- a/lib/puppet/type/openvpnas_userprop.rb
+++ b/lib/puppet/type/openvpnas_userprop.rb
@@ -24,7 +24,7 @@ module Puppet
       format_str = 'Should be in format user-key or group-key!'
       validate do |name|
         raise('Name must be a string') unless name.is_a?(String)
-        raise("Resource name \'#{name}\' is invalid. #{format_str}") unless name =~ %r{^(\w|_|\.)+-(\w|_|\.)+$}
+        raise("Resource name \'#{name}\' is invalid. #{format_str}") unless name =~ %r{^(\w|_|\.|@|-)+-(\w|_|\.)+$}
       end
     end
 


### PR DESCRIPTION
With SAML SSO integration the usernames can be emails, which contain "@" and may contain "-" characters.
The logic to split the userprop resource names into user and key was adjusted to consider the key is the portion after the last "-" and the user is everything before the last "-".