### PR TITLE
Improved user management

### DIFF
--- a/lib/puppet/provider/openvpnas_user/sacli.rb
+++ b/lib/puppet/provider/openvpnas_user/sacli.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'json'
+
+Puppet::Type.type(:openvpnas_user).provide(:sacli) do
+  defaultfor kernel: 'Linux'
+
+  commands sacli: '/usr/local/openvpn_as/scripts/sacli'
+
+  def user
+    resource[:name]
+  end
+
+  def create
+    sacli('--user',  user,
+          '--key',   'type',
+          '--value', 'user_connect',
+          'UserPropPut')
+  end
+
+  def destroy
+    sacli('--user', user,
+          'UserPropDelAll')
+  end
+
+  def self.instances
+    res = []
+    sacli_output = sacli('UserPropGet')
+    config = JSON.parse(sacli_output)
+
+    Puppet.debug(config)
+    config.each do |entry|
+      Puppet.debug("Found userprop entry: #{entry}")
+        res << new(name: "#{entry[0]}", ensure: :present) unless entry[0] == '__DEFAULT__'
+    end
+    res
+  end
+
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if (resource = resources[prov.name])
+        resource.provider = prov
+        Puppet.debug(prov)
+      end
+    end
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+end

--- a/lib/puppet/provider/openvpnas_userprop/sacli.rb
+++ b/lib/puppet/provider/openvpnas_userprop/sacli.rb
@@ -39,7 +39,7 @@ Puppet::Type.type(:openvpnas_userprop).provide(:sacli) do
       entry[1].each_pair do |key, value|
         res << new(name: "#{entry[0]}-#{key}",
                    ensure: :present,
-                   value: value)
+                   value: value) unless key == 'type'
       end
     end
     res

--- a/lib/puppet/type/openvpnas_user.rb
+++ b/lib/puppet/type/openvpnas_user.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+#
+module Puppet
+  Type.newtype(:openvpnas_user) do
+    @doc = 'Manage OpenVPN Access Server users'
+
+    ensurable do
+      desc 'Add or remove user'
+
+      newvalue(:present) do
+        provider.create
+      end
+
+      newvalue(:absent) do
+        provider.destroy
+      end
+
+      defaultto :present
+    end
+
+    newparam(:name, namevar: true) do
+      desc 'The username.'
+      validate do |name|
+        raise('Name must be a string') unless name.is_a?(String)
+        raise("Resource name \'#{name}\' is invalid. #{format_str}") unless name =~ %r{^(\w|_|\.|@|-)+$}
+      end
+    end
+  end
+end

--- a/lib/puppet/type/openvpnas_userprop.rb
+++ b/lib/puppet/type/openvpnas_userprop.rb
@@ -24,6 +24,7 @@ module Puppet
       format_str = 'Should be in format user-key or group-key!'
       validate do |name|
         raise('Name must be a string') unless name.is_a?(String)
+        raise('Name must not end with \'-type\'') if name.end_with?('-type')
         raise("Resource name \'#{name}\' is invalid. #{format_str}") unless name =~ %r{^(\w|_|\.|@|-)+-(\w|_|\.)+$}
       end
     end

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -1,0 +1,7 @@
+define openvpnas::user (
+  String $ensure = present,
+) {
+  openvpnas_user { $name:
+    ensure => $ensure
+  }
+}

--- a/spec/unit/puppet/type/openvpnas_user_spec.rb
+++ b/spec/unit/puppet/type/openvpnas_user_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:openvpnas_user) do
+  let(:default_config) do
+    {
+      name: 'test-user',
+    }
+  end
+
+  let(:config) do
+    default_config
+  end
+
+  let(:resource) do
+    described_class.new(config)
+  end
+
+  it 'can be added to catalog with sane values' do
+    catalog = Puppet::Resource::Catalog.new
+    expect {
+      catalog.add_resource resource
+    }.not_to raise_error
+  end
+
+  bad_names = ['-', '--', 'foo', '-foo', 'foo-', 'foo-bar-foo']
+  bad_names.each do |name|
+    context "should fail with bad name #{name}" do
+      let(:config) do
+        super().merge(name: name)
+      end
+
+      let(:resource) do
+        described_class.new(config)
+      end
+
+      it 'cannot be added to catalog with bad name' do
+        catalog = Puppet::Resource::Catalog.new
+        expect {
+          catalog.add_resource resource
+        }.to raise_error(Puppet::ResourceError)
+      end
+    end
+  end
+end

--- a/spec/unit/puppet/type/openvpnas_userprop_spec.rb
+++ b/spec/unit/puppet/type/openvpnas_userprop_spec.rb
@@ -23,7 +23,7 @@ describe Puppet::Type.type(:openvpnas_userprop) do
     }.not_to raise_error
   end
 
-  bad_names = ['-', '--', 'foo', '-foo', 'foo-', 'foo-bar-foo']
+  bad_names = ['-', '--', 'foo', '-foo', 'foo-', 'foo-bar-foo', 'foo-type']
   bad_names.each do |name|
     context "should fail with bad name #{name}" do
       let(:config) do


### PR DESCRIPTION
This PR creates a new `openvpnas_user` resource type, primarily to expose the `UserPropDelAll` API call to allow puppet to _remove_ users from OpenVPN AS, which is not otherwise possible with the `openvpnas_userprop` resource.

This addresses #1 .  The code works, but it's my first attempt to create a puppet type so it's possible that I've omitted some stuff.